### PR TITLE
Added HTTP Client benchmarks

### DIFF
--- a/http_client/Dockerfile
+++ b/http_client/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache tini wrk apache2 libcurl openssl && \
 # Install build-time dependencies, builds requirements, then unintsall build-time dependencies
 # This is done in one step, so as to not require squashing
 RUN apk add --no-cache gcc musl-dev make curl-dev openssl-dev g++ && \
-    pip install urllib3 requests pycurl aiohttp cchardet aiodns uvloop trio asks vibora && \
+    pip install urllib3 requests pycurl aiohttp cchardet aiodns uvloop trio asks vibora tornado && \
     apk del --purge gcc musl-dev make curl-dev openssl-dev g++
 
 # Install custom code & config files

--- a/http_client/Dockerfile
+++ b/http_client/Dockerfile
@@ -1,0 +1,24 @@
+# ####################################################################
+# HTTP Client benchmarks
+# This isn't to get the "fastest" results, but a comparable result
+#  hence my choice of Apache2 as I could turn pipelining off
+#  so we can see if pipelining works correctly.
+# ####################################################################
+FROM python:3.6-alpine3.7
+WORKDIR /app/
+
+# Install and set-up run-time dependancies
+RUN apk add --no-cache tini wrk apache2 libcurl openssl && \
+    mkdir /run/apache2
+
+# Install build-time dependencies, builds requirements, then unintsall build-time dependencies
+# This is done in one step, so as to not require squashing
+RUN apk add --no-cache gcc musl-dev make curl-dev openssl-dev g++ && \
+    pip install urllib3 requests pycurl aiohttp cchardet aiodns uvloop trio asks vibora && \
+    apk del --purge gcc musl-dev make curl-dev openssl-dev g++
+
+# Install custom code & config files
+COPY app/ /app/
+
+# Entrypoint with zombie reaper
+CMD ["/sbin/tini", "--", "/app/entrypoint.sh"]

--- a/http_client/README.md
+++ b/http_client/README.md
@@ -1,0 +1,44 @@
+HTTP Client Benchmarks
+======================
+
+Run on an Intel Core i5 6300U (dual core skylake) in a docker container.
+
+This isn't to get the "fastest" results, but a comparable result hence my choice of Apache2 as I could turn pipelining off so we can see if pipelining works correctly.
+I kept each benchmark to a single process.
+
+
+WRK is used as a baseline of what a top performer should be.
+
+Results:
+--------
+
+SYNC              | Conn=1           | Pipelined Conn=1 
+------------------|------------------|------------------
+Requests          |           600.05 |           503.69 
+Requests Opt      |           696.35 |           772.96 
+urllib3           |          1318.85 |          1288.89 
+urllib3 Opt       |          1515.80 |          1994.73 
+PyCurl            |          4449.58 |          4518.28 
+PyCurl Opt        |          5159.89 |         10255.08 
+
+ASYNC             | Conn=1           | Conn=10          | Pipelined Conn=1 | Pipelined Conn=10
+------------------|------------------|------------------|------------------|------------------
+asks_trio         |           528.99 |           653.09 |           500.41 |           651.84 
+asks_trio Opt     |           534.12 |           671.15 |          1201.38 |          1447.16 
+aioHTTP           |           742.28 |          1050.93 |           455.42 |           976.85 
+aioHTTP Opt       |           716.31 |          1136.30 |          1503.64 |          1768.74 
+aioHTTP Opt UVloop|           985.65 |          1359.10 |          1631.60 |          2027.08 
+vibora Opt        |          2255.25 |          3832.62 |           868.08 |          4160.42 
+
+WRK               | Conn=1           | Conn=10          | Pipelined Conn=1 | Pipelined Conn=10
+------------------|------------------|------------------|------------------|------------------
+WRK Opt           |          5880.15 |         12793.40 |         15586.79 |         36713.39 
+
+Usage:
+------
+
+On a system that has Docker, just run:
+```sh
+./go.sh
+```
+It should generate the result table for you.

--- a/http_client/app/aiohttp/bench.py
+++ b/http_client/app/aiohttp/bench.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import aiohttp
+import asyncio
+import time
+import sys
+from typing import Tuple
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    while (now - start < duration):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                await resp.read()
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/aiohttp/bench_opt.py
+++ b/http_client/app/aiohttp/bench_opt.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import aiohttp
+import asyncio
+import time
+import sys
+from typing import Tuple
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    async with aiohttp.ClientSession() as session:
+        while (now - start < duration):
+            async with session.get(url) as resp:
+                await resp.read()
+            count += 1
+            now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/aiohttp/bench_opt_uvloop.py
+++ b/http_client/app/aiohttp/bench_opt_uvloop.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import aiohttp
+import asyncio
+import time
+import sys
+from typing import Tuple
+import uvloop
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    async with aiohttp.ClientSession() as session:
+        while (now - start < duration):
+            async with session.get(url) as resp:
+                await resp.read()
+            count += 1
+            now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/asks_trio/bench.py
+++ b/http_client/app/asks_trio/bench.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import asks
+import trio
+import time
+import sys
+from typing import List, Tuple
+asks.init('trio')
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker(tasks: List[Tuple[int, float]]) -> None:
+    count = 0
+    start = now = time.time()
+    while (now - start < duration):
+        await asks.get(url)
+        count += 1
+        now = time.time()
+
+    tasks.append((count, now - start))
+
+async def bench():
+    tasks = []
+    async with trio.open_nursery() as nursery:
+        for val in range(concurrency):
+            nursery.start_soon(worker, tasks)
+
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        count += task[0]
+        duration += task[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+
+trio.run(bench)
+

--- a/http_client/app/asks_trio/bench_opt.py
+++ b/http_client/app/asks_trio/bench_opt.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import asks
+import trio
+import time
+import sys
+from typing import List, Tuple
+asks.init('trio')
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker(tasks: List[Tuple[int, float]]) -> None:
+    count = 0
+    start = now = time.time()
+    s = asks.Session()
+    while (now - start < duration):
+        await s.get(url)
+        count += 1
+        now = time.time()
+
+    tasks.append((count, now - start))
+
+async def bench():
+    tasks = []
+    async with trio.open_nursery() as nursery:
+        for val in range(concurrency):
+            nursery.start_soon(worker, tasks)
+
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        count += task[0]
+        duration += task[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+
+trio.run(bench)
+

--- a/http_client/app/benchmarks.sh
+++ b/http_client/app/benchmarks.sh
@@ -70,6 +70,27 @@ echo ASYNC: vibora: Opt $DESC | tee -a /app/out
 echo | tee -a /app/out
 sleep $PAUSE
 
+# Tornado
+echo ASYNC: Tornado.simple: $DESC | tee -a /app/out
+/app/tornado/bench.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: Tornado.simple: UVloop $DESC | tee -a /app/out
+/app/tornado/bench_uvloop.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: Tornado.curl: $DESC | tee -a /app/out
+/app/tornado/bench_curl.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: Tornado.curl: UVloop $DESC | tee -a /app/out
+/app/tornado/bench_curl_uvloop.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
 # WRK
 echo WRK: WRK: Opt $DESC | tee -a /app/out
 wrk -d ${DURATION}s -t 1 -c $CONS $URL | tee -a /app/out

--- a/http_client/app/benchmarks.sh
+++ b/http_client/app/benchmarks.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+if [ "X$CONS" == "X1" ]; then
+# Requests
+echo SYNC: Requests: $DESC | tee -a /app/out
+/app/requests/bench.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo SYNC: Requests: Opt $DESC | tee -a /app/out
+/app/requests/bench_session.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+
+# urllib3
+echo SYNC: urllib3: $DESC | tee -a /app/out
+/app/urllib3/bench.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo SYNC: urllib3: Opt $DESC | tee -a /app/out
+/app/urllib3/bench_session.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+
+# PyCurl
+echo SYNC: PyCurl: $DESC | tee -a /app/out
+/app/pycurl/bench.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo SYNC: PyCurl: Opt $DESC | tee -a /app/out
+/app/pycurl/bench_session.py $URL $DURATION | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+fi
+
+# asks_trio
+echo ASYNC: asks_trio: $DESC | tee -a /app/out
+/app/asks_trio/bench.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: asks_trio: Opt $DESC | tee -a /app/out
+/app/asks_trio/bench_opt.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+# aioHTTP
+echo ASYNC: aioHTTP: $DESC | tee -a /app/out
+/app/aiohttp/bench.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: aioHTTP: Opt $DESC | tee -a /app/out
+/app/aiohttp/bench_opt.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+echo ASYNC: aioHTTP: Opt UVloop $DESC | tee -a /app/out
+/app/aiohttp/bench_opt_uvloop.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+# Vibora
+echo ASYNC: vibora: Opt $DESC | tee -a /app/out
+/app/vibora/bench.py $URL $DURATION $CONS | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE
+
+# WRK
+echo WRK: WRK: Opt $DESC | tee -a /app/out
+wrk -d ${DURATION}s -t 1 -c $CONS $URL | tee -a /app/out
+echo | tee -a /app/out
+sleep $PAUSE

--- a/http_client/app/entrypoint.sh
+++ b/http_client/app/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+# Configure Apache2
+echo "ServerName 127.0.0.1:80" >> /etc/apache2/httpd.conf
+sed -i 's/^LoadModule log_config_module .*$//g' /etc/apache2/httpd.conf
+sed -i 's/^LoadModule mpm_prefork_module .*$//g' /etc/apache2/httpd.conf
+sed -i 's/^#LoadModule mpm_worker_module/LoadModule mpm_worker_module/g' /etc/apache2/httpd.conf
+# Launch Apache2
+httpd -k start
+sleep 2
+
+echo '' > /app/out
+
+export URL=http://127.0.0.1/index.html
+export DURATION=2
+export PAUSE=4
+
+export CONS=1
+sleep $PAUSE
+DESC='Pipelined, Concurrency:1' /app/benchmarks.sh
+
+export CONS=10
+sleep $PAUSE
+DESC='Pipelined, Concurrency:10' /app/benchmarks.sh
+
+# Configure Apache2 to force disale pipelining
+sed -i 's/^KeepAlive On$/KeepAlive Off/g' /etc/apache2/conf.d/default.conf
+# Restart Apache2
+httpd -k restart
+export PAUSE=15
+
+export CONS=1
+sleep $PAUSE
+DESC='No Pipelining, Concurrency:1' /app/benchmarks.sh
+
+export CONS=10
+sleep $PAUSE
+DESC='No Pipelining, Concurrency:10' /app/benchmarks.sh
+
+# Print report to screen
+cat /app/out | ./present.py

--- a/http_client/app/present.py
+++ b/http_client/app/present.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import re
+import sys
+
+val = sys.stdin.read()
+
+vals = [text.strip() for text in val.strip().split('\n\n')]
+
+groups = {}
+
+for bench in vals:
+    desc = bench.split('\n')[0]
+    group = desc.split(':')[0].strip()
+    app = desc.split(':')[1].strip()
+    pipelined = 'Pipelined' if 'Pipelined' in desc else ''
+    opt = ' Opt' if 'Opt' in desc else ''
+    uvloop = ' UVloop' if 'UVloop' in desc else ''
+    cons = re.search(r'Concurrency:(\d+)', desc).group(1)
+    reqs = re.search(r'\nRequests/sec:\s*([\d\.]+)', bench).group(1)
+    spec = f'{app}{opt}{uvloop}'
+    subspec = f'{pipelined} Conn={cons}'.strip()
+    groups.setdefault(group, {}).setdefault(spec, {})[subspec] = reqs
+
+for gname, group in groups.items():
+    _subspecs = set()
+    for sname, spec in group.items():
+        _subspecs.update(list(spec.keys()))
+    subspecs = sorted(_subspecs)
+
+    cols = ""
+    cold = ""
+    for col in subspecs:
+        cols += f"| {col:17}"
+        cold += f"|{'-'*18}"
+    print(f'\n{gname:18}{cols}')
+    print(f"{'-'*18}{cold}")
+    for sname, spec in group.items():
+        cols = ""
+        for col in subspecs:
+            cols += f"|{spec.get(col,''):>17} "
+        print(f'{sname:18}{cols}')

--- a/http_client/app/pycurl/bench.py
+++ b/http_client/app/pycurl/bench.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import pycurl
+from io import BytesIO
+import time
+import sys
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+
+start = now = time.time()
+
+while (now - start < duration):
+    bfr = BytesIO()
+    c = pycurl.Curl()
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, bfr)
+    c.perform()
+    c.close()
+
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/pycurl/bench_session.py
+++ b/http_client/app/pycurl/bench_session.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import pycurl
+from io import BytesIO
+import time
+import sys
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+c = pycurl.Curl()
+
+start = now = time.time()
+
+while (now - start < duration):
+    bfr = BytesIO()
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, bfr)
+    c.perform()
+
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/requests/bench.py
+++ b/http_client/app/requests/bench.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import requests
+import time
+import sys
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+
+start = now = time.time()
+
+while (now - start < duration):
+    requests.get(url)
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/requests/bench_session.py
+++ b/http_client/app/requests/bench_session.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import requests
+import time
+import sys
+
+session = requests.Session()
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+
+start = now = time.time()
+
+while (now - start < duration):
+    session.get(url)
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/tornado/bench.py
+++ b/http_client/app/tornado/bench.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from tornado import simple_httpclient
+import asyncio
+import time
+import sys
+from typing import Tuple
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    session = simple_httpclient.SimpleAsyncHTTPClient()
+    while (now - start < duration):
+        resp = await session.fetch(url)
+        resp.body
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/tornado/bench_curl.py
+++ b/http_client/app/tornado/bench_curl.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from tornado import curl_httpclient
+import asyncio
+import time
+import sys
+from typing import Tuple
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    session = curl_httpclient.CurlAsyncHTTPClient()
+    while (now - start < duration):
+        resp = await session.fetch(url)
+        resp.body
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/tornado/bench_curl_uvloop.py
+++ b/http_client/app/tornado/bench_curl_uvloop.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from tornado import curl_httpclient
+import asyncio
+import time
+import sys
+from typing import Tuple
+import uvloop
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    session = curl_httpclient.CurlAsyncHTTPClient()
+    while (now - start < duration):
+        resp = await session.fetch(url)
+        resp.body
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/tornado/bench_uvloop.py
+++ b/http_client/app/tornado/bench_uvloop.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from tornado import simple_httpclient
+import asyncio
+import time
+import sys
+from typing import Tuple
+import uvloop
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    session = simple_httpclient.SimpleAsyncHTTPClient()
+    while (now - start < duration):
+        resp = await session.fetch(url)
+        resp.body
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/app/urllib3/bench.py
+++ b/http_client/app/urllib3/bench.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import urllib3
+import time
+import sys
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+
+start = now = time.time()
+
+while (now - start < duration):
+    session = urllib3.PoolManager()
+    session.request('GET', url)
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/urllib3/bench_session.py
+++ b/http_client/app/urllib3/bench_session.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import urllib3
+import time
+import sys
+
+session = urllib3.PoolManager()
+url = sys.argv[1]
+duration = float(sys.argv[2])
+count = 0
+
+print(f'URL: {url}')
+
+start = now = time.time()
+
+while (now - start < duration):
+    session.request('GET', url)
+    count += 1
+    now = time.time()
+
+print(f'  {count} requests in {now-start:.2f}s')
+print(f'Requests/sec:{count / (now-start):10.2f}')

--- a/http_client/app/vibora/bench.py
+++ b/http_client/app/vibora/bench.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from vibora import client
+import asyncio
+import time
+import sys
+from typing import Tuple
+
+url = sys.argv[1]
+duration = float(sys.argv[2])
+concurrency = int(sys.argv[3])
+
+print(f'URL: {url}')
+
+async def worker() -> Tuple[int, float]:
+    count = 0
+    start = now = time.time()
+    while (now - start < duration):
+        await client.get(url)
+        count += 1
+        now = time.time()
+
+    return count, now - start
+
+async def bench():
+    tasks = []
+    for val in range(concurrency):
+        tasks.append(asyncio.ensure_future(worker()))
+    count = 0
+    duration = 0.0
+    for task in tasks:
+        await task
+        res = task.result()
+        count += res[0]
+        duration += res[1]
+
+    print(f'  {count} requests in {duration / concurrency:.2f}s')
+    print(f'Requests/sec:{count / (duration / concurrency):10.2f}')
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(bench())
+

--- a/http_client/go.sh
+++ b/http_client/go.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# echo 10 > /proc/sys/net/ipv4/tcp_fin_timeout
+# echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+docker build -t bench .
+docker run -it bench:latest


### PR DESCRIPTION
Since Vibora has a HTTP client as well, we need representative benchmarks to compare it to other Python clients.

I added this under the `http_client/` directory as it is a separate set of benchmarks for the client library.

Generally `vibora.client` compares favourably, but still trails `PyCurl` (which imo has quite an un-pythonic interface)

When running the HTTP Client benchmarks, it is easy to run into the `TIME_WAIT` and port reuse issue.
I added lots of delays between tests to try and limit the impact, and configured my system with the comments in the `http_client/go.sh` script.

This isn't to get the "fastest" results, but a comparable result hence my choice of Apache2 as I could turn pipelining off so we can see if pipelining works correctly.
I kept each benchmark to a single process.

WRK is used as a baseline of what a top performer should be.

Results:
--------

SYNC              | Conn=1           | Pipelined Conn=1
------------------|------------------|------------------
Requests          |           600.05 |           503.69
Requests Opt      |           696.35 |           772.96
urllib3           |          1318.85 |          1288.89
urllib3 Opt       |          1515.80 |          1994.73
PyCurl            |          4449.58 |          4518.28
PyCurl Opt        |          5159.89 |         10255.08

ASYNC             | Conn=1           | Conn=10          | Pipelined Conn=1 | Pipelined Conn=10
------------------|------------------|------------------|------------------|------------------
asks_trio         |           528.99 |           653.09 |           500.41 |           651.84
asks_trio Opt     |           534.12 |           671.15 |          1201.38 |          1447.16
aioHTTP           |           742.28 |          1050.93 |           455.42 |           976.85
aioHTTP Opt       |           716.31 |          1136.30 |          1503.64 |          1768.74
aioHTTP Opt UVloop|           985.65 |          1359.10 |          1631.60 |          2027.08
Tornado.simple    |           541.97 |           658.93 |           570.55 |           680.83 
Tornado.simple UVloop|           696.26 |           732.79 |           696.98 |           845.45 
Tornado.curl      |          1640.50 |          2186.15 |          1800.59 |          2736.51 
Tornado.curl UVloop|          1725.90 |          2337.01 |          2106.75 |          2852.01 
vibora            |          2255.25 |          3832.62 |           868.08 |          4160.42

WRK               | Conn=1           | Conn=10          | Pipelined Conn=1 | Pipelined Conn=10
------------------|------------------|------------------|------------------|------------------
WRK Opt           |          5880.15 |         12793.40 |         15586.79 |         36713.39

Usage:
------

On a system that has Docker, just run:
```sh
./go.sh
```
It should generate the result table for you.
